### PR TITLE
Bugfix - Handle invalid characters when decoding

### DIFF
--- a/src/Base62/BaseEncoder.php
+++ b/src/Base62/BaseEncoder.php
@@ -15,6 +15,7 @@
 
 namespace Tuupola\Base62;
 
+use InvalidArgumentException;
 use Tuupola\Base62;
 
 abstract class BaseEncoder
@@ -48,6 +49,11 @@ abstract class BaseEncoder
 
     public function decode($data, $integer = false)
     {
+        // If the data contains characters that aren't in the character set
+        if (strlen($data) !== strspn($data, $this->options["characters"])) {
+            throw new InvalidArgumentException('Data contains invalid characters');
+        }
+
         $data = str_split($data);
         $data = array_map(function ($character) {
             return strpos($this->options["characters"], $character);

--- a/src/Base62/BaseEncoder.php
+++ b/src/Base62/BaseEncoder.php
@@ -51,7 +51,7 @@ abstract class BaseEncoder
     {
         // If the data contains characters that aren't in the character set
         if (strlen($data) !== strspn($data, $this->options["characters"])) {
-            throw new InvalidArgumentException('Data contains invalid characters');
+            throw new InvalidArgumentException("Data contains invalid characters");
         }
 
         $data = str_split($data);

--- a/src/Base62/GmpEncoder.php
+++ b/src/Base62/GmpEncoder.php
@@ -15,6 +15,7 @@
 
 namespace Tuupola\Base62;
 
+use InvalidArgumentException;
 use Tuupola\Base62;
 
 class GmpEncoder
@@ -45,6 +46,11 @@ class GmpEncoder
 
     public function decode($data, $integer = false)
     {
+        // If the data contains characters that aren't in the character set
+        if (strlen($data) !== strspn($data, $this->options["characters"])) {
+            throw new InvalidArgumentException('Data contains invalid characters');
+        }
+
         if (Base62::GMP !== $this->options["characters"]) {
             $data = strtr($data, $this->options["characters"], Base62::GMP);
         }

--- a/src/Base62/GmpEncoder.php
+++ b/src/Base62/GmpEncoder.php
@@ -48,7 +48,7 @@ class GmpEncoder
     {
         // If the data contains characters that aren't in the character set
         if (strlen($data) !== strspn($data, $this->options["characters"])) {
-            throw new InvalidArgumentException('Data contains invalid characters');
+            throw new InvalidArgumentException("Data contains invalid characters");
         }
 
         if (Base62::GMP !== $this->options["characters"]) {

--- a/tests/Base62Test.php
+++ b/tests/Base62Test.php
@@ -265,7 +265,7 @@ class Base62Test extends \PHPUnit_Framework_TestCase
 
     public function testShouldThrowExceptionOnDecodeInvalidData()
     {
-        $invalid_data = 'invalid~data-%@#!@*#-foo';
+        $invalid_data = "invalid~data-%@#!@*#-foo";
 
         InvalidArgumentException::class;
 
@@ -291,8 +291,8 @@ class Base62Test extends \PHPUnit_Framework_TestCase
 
     public function testShouldThrowExceptionOnDecodeInvalidDataWithCustomCharacterSet()
     {
-        $invalid_data = 'normallyvaliddata';
-        $character_set = '01abc';
+        $invalid_data = "normallyvaliddata";
+        $character_set = "01abc";
         $options = ["characters" => $character_set];
 
         InvalidArgumentException::class;

--- a/tests/Base62Test.php
+++ b/tests/Base62Test.php
@@ -15,6 +15,7 @@
 
 namespace Tuupola\Base62;
 
+use InvalidArgumentException;
 use Tuupola\Base62;
 use Tuupola\Base62Proxy;
 
@@ -260,5 +261,59 @@ class Base62Test extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($encoded, $encoded5);
         $this->assertEquals($data, $decoded5);
+    }
+
+    public function testShouldThrowExceptionOnDecodeInvalidData()
+    {
+        $invalid_data = 'invalid~data-%@#!@*#-foo';
+
+        InvalidArgumentException::class;
+
+        $decoders = [
+            new PhpEncoder(),
+            new GmpEncoder(),
+            new BcmathEncoder(),
+            new Base62(),
+        ];
+
+        foreach ($decoders as $decoder) {
+            $caught = null;
+
+            try {
+                $decoder->decode($invalid_data, false);
+            } catch (InvalidArgumentException $e) {
+                $caught = $e;
+            }
+
+            $this->assertInstanceOf(InvalidArgumentException::class, $caught);
+        }
+    }
+
+    public function testShouldThrowExceptionOnDecodeInvalidDataWithCustomCharacterSet()
+    {
+        $invalid_data = 'normallyvaliddata';
+        $character_set = '01abc';
+        $options = ["characters" => $character_set];
+
+        InvalidArgumentException::class;
+
+        $decoders = [
+            new PhpEncoder($options),
+            new GmpEncoder($options),
+            new BcmathEncoder($options),
+            new Base62($options),
+        ];
+
+        foreach ($decoders as $decoder) {
+            $caught = null;
+
+            try {
+                $decoder->decode($invalid_data, false);
+            } catch (InvalidArgumentException $e) {
+                $caught = $e;
+            }
+
+            $this->assertInstanceOf(InvalidArgumentException::class, $caught);
+        }
     }
 }


### PR DESCRIPTION
When using this library in a project, I ran into an issue when I wrote a test that passed intentionally "bad data" to the `decode` method.

Specifically, when passing the invalid data to the decode method of the `GmpEncoder`, which uses `gmp_init()`, the GMP extension was throwing an unchecked warning about the data not being a valid number within the specified base (62).

I've recreated this error in the provided tests, along with a fix:
<img width="522" alt="screen shot 2018-03-26 at 6 53 48 pm" src="https://user-images.githubusercontent.com/742384/37940659-123da366-3127-11e8-9f88-eaab9d1d9376.png">

... Unfortunately, there's not a great way to check for this error at a higher level, due to GMP's usage of warnings and a `false` return value. Interestingly enough, I've actually run into this problem before [when building my own library years ago](https://github.com/Rican7/mathematician), so I've actually reported this as a PHP bug, but it was closed with a "Won't Fix" status: https://bugs.php.net/bug.php?id=68002

In any case, I've created this fix to handle the issue for both the GMP encoder's case and for the base encoder, as otherwise not handling this case could lead to an invalid decode result or "data-loss".