### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "overtrue/phplint": "^0.2.4"
     },
     "suggest": {
-        "ext-gmp": "This extension will generate the encoded string fastly.",
-        "ext-bcmath": "This extension will generate the encoded string fastly."
+        "ext-gmp": "This extension will generate the encoded string fastly."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.5",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8|^5.5|^6.5",
         "paragonie/random_compat": "^2.0",
         "phpbench/phpbench": "^0.13.0",
         "overtrue/phplint": "^0.2.4"

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "overtrue/phplint": "^0.2.4"
     },
     "suggest": {
-        "ext-gmp": "This extension will generate the encoded string fastly."
+        "ext-gmp": "This extension will generate the encoded string fastly.",
+        "ext-bcmath": "This extension will generate the encoded string fastly."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,8 @@
         "paragonie/random_compat": "^2.0",
         "phpbench/phpbench": "^0.13.0",
         "overtrue/phplint": "^0.2.4"
+    },
+    "suggest": {
+        "ext-gmp": "This extension will generate the encoded string fastly."
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,8 +6,8 @@
         </testsuite>
     </testsuites>
     <filter>
-        <blacklist>
-            <directory suffix=".php">vendor/</directory>
-        </blacklist>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
     </filter>
 </phpunit>

--- a/tests/Base62Test.php
+++ b/tests/Base62Test.php
@@ -18,8 +18,9 @@ namespace Tuupola\Base62;
 use InvalidArgumentException;
 use Tuupola\Base62;
 use Tuupola\Base62Proxy;
+use PHPUnit\Framework\TestCase;
 
-class Base62Test extends \PHPUnit_Framework_TestCase
+class Base62Test extends TestCase
 {
 
     public function testShouldBeTrue()


### PR DESCRIPTION
# Changed log

- add the suggested extension: ```ext-gmp``` and ```ext-bcmath```.
- using the class-based PHPUnit namespace.
- consider the ```php-7.2``` test will output some deprecated and warning message when using the PHPUnit version ```4.8```.
See more details about the [Travis build log](https://travis-ci.org/peter279k/base62/jobs/365698483).