### PR TITLE
[FIX] do not discard zero-byte prefixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,6 @@
         "overtrue/phplint": "^0.2.4"
     },
     "suggest": {
-        "ext-gmp": "This extension will generate the encoded string fastly."
+        "ext-gmp": "This extension will generate the encoded string faster."
     }
 }

--- a/src/Base62/BaseEncoder.php
+++ b/src/Base62/BaseEncoder.php
@@ -49,10 +49,14 @@ abstract class BaseEncoder
             array_shift($data);
         }
 
-        $converted = array_merge(
-            array_fill(0, $leadingZeroes, 0),
-            $this->baseConvert($data, 256, 62)
-        );
+        $converted = $this->baseConvert($data, 256, 62);
+
+        if (0 < $leadingZeroes) {
+            $converted = array_merge(
+                array_fill(0, $leadingZeroes, 0),
+                $converted
+            );
+        }
 
         return implode("", array_map(function ($index) {
             return $this->options["characters"][$index];
@@ -83,10 +87,14 @@ abstract class BaseEncoder
             return (integer) implode("", $converted);
         }
 
-        $converted = array_merge(
-            array_fill(0, $leadingZeroes, 0),
-            $this->baseConvert($data, 62, 256)
-        );
+        $converted = $this->baseConvert($data, 62, 256);
+
+        if (0 < $leadingZeroes) {
+            $converted = array_merge(
+                array_fill(0, $leadingZeroes, 0),
+                $converted
+            );
+        }
 
         return implode("", array_map("chr", $converted));
     }

--- a/src/Base62/BaseEncoder.php
+++ b/src/Base62/BaseEncoder.php
@@ -40,12 +40,19 @@ abstract class BaseEncoder
             $data = [$data];
         } else {
             $data = str_split($data);
-            $data = array_map(function ($character) {
-                return ord($character);
-            }, $data);
+            $data = array_map("ord", $data);
         }
 
-        $converted = $this->baseConvert($data, 256, 62);
+        $leadingZeroes = 0;
+        while (!empty($data) && 0 === $data[0]) {
+            $leadingZeroes++;
+            array_shift($data);
+        }
+
+        $converted = array_merge(
+            array_fill(0, $leadingZeroes, 0),
+            $this->baseConvert($data, 256, 62)
+        );
 
         return implode("", array_map(function ($index) {
             return $this->options["characters"][$index];
@@ -64,17 +71,24 @@ abstract class BaseEncoder
             return strpos($this->options["characters"], $character);
         }, $data);
 
+        $leadingZeroes = 0;
+        while (!empty($data) && 0 === $data[0]) {
+            $leadingZeroes++;
+            array_shift($data);
+        }
+
         /* Return as integer when requested. */
         if ($integer) {
             $converted = $this->baseConvert($data, 62, 10);
             return (integer) implode("", $converted);
         }
 
-        $converted = $this->baseConvert($data, 62, 256);
+        $converted = array_merge(
+            array_fill(0, $leadingZeroes, 0),
+            $this->baseConvert($data, 62, 256)
+        );
 
-        return implode("", array_map(function ($ascii) {
-            return chr($ascii);
-        }, $converted));
+        return implode("", array_map("chr", $converted));
     }
 
     public function encodeInteger($data)

--- a/src/Base62/GmpEncoder.php
+++ b/src/Base62/GmpEncoder.php
@@ -49,6 +49,12 @@ class GmpEncoder
                 $hex = substr($hex, 2);
             }
 
+            // Prior to PHP 7.0 substr() returns false
+            // instead of the empty string
+            if (false === $hex) {
+                $hex = '';
+            }
+
             // gmp_init() cannot cope with a zero-length string
             if ('' === $hex) {
                 return str_repeat($this->options["characters"][0], $leadZeroBytes);
@@ -78,6 +84,12 @@ class GmpEncoder
         while ('' !== $data && 0 === strpos($data, $this->options["characters"][0])) {
             $leadZeroBytes++;
             $data = substr($data, 1);
+        }
+
+        // Prior to PHP 7.0 substr() returns false
+        // instead of the empty string
+        if (false === $data) {
+            $data = '';
         }
 
         // gmp_init() cannot cope with a zero-length string

--- a/src/Base62/GmpEncoder.php
+++ b/src/Base62/GmpEncoder.php
@@ -44,7 +44,7 @@ class GmpEncoder
             $hex = bin2hex($data);
 
             $leadZeroBytes = 0;
-            while ('' !== $hex && 0 === strpos($hex, '00')) {
+            while ("" !== $hex && 0 === strpos($hex, "00")) {
                 $leadZeroBytes++;
                 $hex = substr($hex, 2);
             }
@@ -52,11 +52,11 @@ class GmpEncoder
             // Prior to PHP 7.0 substr() returns false
             // instead of the empty string
             if (false === $hex) {
-                $hex = '';
+                $hex = "";
             }
 
             // gmp_init() cannot cope with a zero-length string
-            if ('' === $hex) {
+            if ("" === $hex) {
                 return str_repeat($this->options["characters"][0], $leadZeroBytes);
             }
 
@@ -81,7 +81,7 @@ class GmpEncoder
         }
 
         $leadZeroBytes = 0;
-        while ('' !== $data && 0 === strpos($data, $this->options["characters"][0])) {
+        while ("" !== $data && 0 === strpos($data, $this->options["characters"][0])) {
             $leadZeroBytes++;
             $data = substr($data, 1);
         }
@@ -89,11 +89,11 @@ class GmpEncoder
         // Prior to PHP 7.0 substr() returns false
         // instead of the empty string
         if (false === $data) {
-            $data = '';
+            $data = "";
         }
 
         // gmp_init() cannot cope with a zero-length string
-        if ('' === $data) {
+        if ("" === $data) {
             return str_repeat("\x00", $leadZeroBytes);
         }
 
@@ -107,7 +107,7 @@ class GmpEncoder
             return hexdec($hex);
         }
 
-        return hex2bin(str_repeat('00', $leadZeroBytes) . $hex);
+        return hex2bin(str_repeat("00", $leadZeroBytes) . $hex);
     }
 
     public function encodeInteger($data)

--- a/src/Base62/PhpEncoder.php
+++ b/src/Base62/PhpEncoder.php
@@ -37,8 +37,8 @@ class PhpEncoder extends BaseEncoder
                 $digit = ($accumulator - ($accumulator % $target_base)) / $target_base;
                 $remainder = $accumulator % $target_base;
                 if (count($quotient) || $digit) {
-                    array_push($quotient, $digit);
-                };
+                    $quotient[] = $digit;
+                }
             }
             array_unshift($result, $remainder);
             $source = $quotient;

--- a/tests/Base62Test.php
+++ b/tests/Base62Test.php
@@ -359,4 +359,29 @@ class Base62Test extends TestCase
             $this->assertInstanceOf(InvalidArgumentException::class, $caught);
         }
     }
+
+    /**
+     * @dataProvider zeroPrefixProvider
+     */
+    public function testEncodingAZeroBitStream($data)
+    {
+        $bcEncoder = new BcmathEncoder();
+        $gmpEncoder = new GmpEncoder();
+        $phpEncoder = new PhpEncoder();
+
+        $this->assertSame($data, $bcEncoder->decode($bcEncoder->encode($data)));
+        $this->assertSame($data, $gmpEncoder->decode($gmpEncoder->encode($data)));
+        $this->assertSame($data, $phpEncoder->decode($phpEncoder->encode($data)));
+    }
+
+    public function zeroPrefixProvider()
+    {
+        return [
+            'no leading zero bytes' => ["\x01"],
+            'single zero byte' => ["\x00"],
+            'multiple zero bytes' => ["\x00\x00"],
+            'single zero byte prefix' => ["\x00\x01"],
+            'multiple zero byte prefix' => ["\x00\x00\x00\x01"]
+        ];
+    }
 }

--- a/tests/Base62Test.php
+++ b/tests/Base62Test.php
@@ -377,11 +377,11 @@ class Base62Test extends TestCase
     public function zeroPrefixProvider()
     {
         return [
-            'no leading zero bytes' => ["\x01"],
-            'single zero byte' => ["\x00"],
-            'multiple zero bytes' => ["\x00\x00"],
-            'single zero byte prefix' => ["\x00\x01"],
-            'multiple zero byte prefix' => ["\x00\x00\x00\x01"]
+            "no leading zero bytes" => ["\x01"],
+            "single zero byte" => ["\x00"],
+            "multiple zero bytes" => ["\x00\x00"],
+            "single zero byte prefix" => ["\x00\x01"],
+            "multiple zero byte prefix" => ["\x00\x00\x00\x01"]
         ];
     }
 }


### PR DESCRIPTION
Since the encoding algorithm is based on arithmetic division, the current algorithm is discarding `0x00` bytes at the beginning of the data stream.

Examples:
`0x0001` -(encode)-> `0x31` -(decode)-> `0x01`
`0x00000000` -(encode)-> `0x00` -(decode)-> `0x00`
`0x303030` -(decode)-> `0x00`

The fix I came up with involves chopping these leading zero-bytes from the data stream and appending their encoded (or decoded) form after performing the division. There's also a new test case for this corner case.


PS Fixes #4. Had not seen the issue.