### PR TITLE
Change from phpdbg to xdebug for coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: gmp
+          coverage: xdebug
           #coverage: pcov
       - name: Set composer cache
         id: composer-cache

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint: vendor
 	vendor/bin/phpcs -p --standard=PSR2 --extensions=php --encoding=utf-8 --ignore=*/vendor/*,*/benchmarks/* .
 
 unit: vendor
-	phpdbg -qrr vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml --coverage-html=./report/
+	vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml --coverage-html=./report/
 
 static: vendor
 	vendor/bin/phpstan analyse src --level max


### PR DESCRIPTION
Currently running tests with phpdbg dumps core with PHP 7.1, 7.2 and 7.3.

https://github.com/tuupola/base62/actions/runs/686429975