### PR TITLE
Add tests for PHP 8.3 and 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]
+        php-versions: ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
Bumped PHP version from 8.2 to 8.4 for tests.

Looks like this is [the most popular base62 en/decoder around](https://packagist.org/?query=base62) so it's worth of keeping it up to date.