### PR TITLE
Fix PHP 8.1 encoding empty string as 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Changed
 - Throw an exception if trying to encode a negative integer ([#35](https://github.com/tuupola/base62/pull/35))
 
+### Fixed
+- PHP 8.1 encoded empty string as 0  ([#36](https://github.com/tuupola/base62/pull/36))
+
 ## [2.1.0](https://github.com/tuupola/base62/compare/2.0.0...2.1.0) - 2020-09-09
 
 ### Added

--- a/src/Base62/BaseEncoder.php
+++ b/src/Base62/BaseEncoder.php
@@ -61,6 +61,10 @@ abstract class BaseEncoder
      */
     public function encode(string $data): string
     {
+        if ("" === $data) {
+            return "";
+        }
+
         $data = str_split($data);
         $data = array_map("ord", $data);
 
@@ -87,6 +91,10 @@ abstract class BaseEncoder
     public function decode(string $data): string
     {
         $this->validateInput($data);
+
+        if ("" === $data) {
+            return "";
+        }
 
         $data = str_split($data);
         $data = array_map(function ($character) {


### PR DESCRIPTION
In PHP 8.2 and later, calling str_split("") returns an empty array []. 
PHP 8.1 had a bug and it returns an array containing a single empty 
string [""].